### PR TITLE
mkdir should return ENOENT on Java 6 for non existent parent dirs

### DIFF
--- a/core/src/main/java/io/apigee/trireme/core/modules/Filesystem.java
+++ b/core/src/main/java/io/apigee/trireme/core/modules/Filesystem.java
@@ -727,17 +727,18 @@ public class Filesystem
         {
             File file = translatePath(path);
             if (file.exists()) {
-                NodeOSException ne = new NodeOSException(Constants.EEXIST);
-                ne.setPath(path);
-                throw ne;
+                throw new NodeOSException(Constants.EEXIST, path);
+            }
+            if (file.getParentFile() != null && !file.getParentFile().exists()) {
+                throw new NodeOSException(Constants.ENOENT, path);
             }
             if (!file.mkdir()) {
-                throw new NodeOSException(Constants.EIO);
+                throw new NodeOSException(Constants.EIO, path);
             }
             try {
                 setMode(file, mode);
             } catch (IOException ioe) {
-                throw new NodeOSException(Constants.EIO, ioe);
+                throw new NodeOSException(Constants.EIO, ioe, path);
             }
         }
 


### PR DESCRIPTION
Corrected `mkdir` for Java 6 such that if there is a parent directory but it does not exist then `ENOENT` is thrown. Node actually isn't clear on what should happen here, but the `mkdirp` module [certainly expects `ENOENT`](https://github.com/substack/node-mkdirp/blob/master/index.js#L23). In addition the Trireme Java 7 version functions correctly with `mkdirp`. I would think that Java 7 works because a [FileNotFoundException](https://github.com/apigee/trireme/blob/master/core/src/main/java/io/apigee/trireme/core/modules/AsyncFilesystem.java#L218) is turned into `ENOENT` within AsyncFileSystem.

In addition all node exceptions within `mkdir` now communicate the path in the spirit of providing sufficient debug.
