### PR TITLE
unsigned conversion to stay in single character code points

### DIFF
--- a/core/src/main/java/io/apigee/trireme/core/internal/charsets/BinaryCharset.java
+++ b/core/src/main/java/io/apigee/trireme/core/internal/charsets/BinaryCharset.java
@@ -106,7 +106,7 @@ public class BinaryCharset
                 if (!out.hasRemaining()) {
                     return CoderResult.OVERFLOW;
                 }
-                char c = (char)in.get();
+                char c = (char)(in.get() & 0xff); // unsigned conversion to stay in single character code points!
                 out.put(c);
             }
             return CoderResult.UNDERFLOW;


### PR DESCRIPTION
This avoids sign extension for binary data in the range of 128..255. With the fix any byte is mapped to the Unicode codepoints \u0000...\u00FF.
