### PR TITLE
adding support for unwrapping Wrapper objects

### DIFF
--- a/core/src/main/java/io/apigee/trireme/core/ArgUtils.java
+++ b/core/src/main/java/io/apigee/trireme/core/ArgUtils.java
@@ -314,6 +314,13 @@ public class ArgUtils
             if (type.isInstance(args[pos])) {
                 return type.cast(args[pos]);
             } else {
+                Object arg = args[pos];
+                while(arg instanceof org.mozilla.javascript.Wrapper) {
+                    arg = ((org.mozilla.javascript.Wrapper)arg).unwrap();
+                    if(type.isInstance(arg)) {
+                        return type.cast(arg);
+                    }
+                }
                 if (required) {
                     throw new EvaluatorException("Object of type " + type + " expected");
                 } else {


### PR DESCRIPTION
This change enables passing Wrapper Scriptables from JavaScript code to Java which uses ArgUtils.objArg() to extract some argument. The addition is useful when glue code is used to interface with existing Java code.
