### PR TITLE
fix to emit error objects such that npm recognizes SSL errors

### DIFF
--- a/node10/node10src/src/main/javascript/io/apigee/trireme/node10/trireme/tls.js
+++ b/node10/node10src/src/main/javascript/io/apigee/trireme/node10/trireme/tls.js
@@ -731,6 +731,7 @@ CleartextStream.prototype.handleSSLError = function(err) {
     debug(this.id + ' Received an error (handshake complete = ' +
           this.handshakeComplete + '): ' + err);
   }
+  err = new Error('SSL Error: ' + err); // fix to emit error objects such that npm recognizes SSL errors
   if (this.handshakeComplete) {
     this.emit('error', err);
     doClose(this, true);


### PR DESCRIPTION
The method handleSSLError() is called passing a string as error message in all places. However, the event emitter did not emit Error objects but just the message string. Notice also, the error message is prefixed by 'SSL Error: ' because NPM checks the error object's message for that string to detect whether an error is caused by some SSL processing. In Trireme, the message originates either from hard coded texts or from SSLExceptions in some cases.
