### PR TITLE
missing path translation

### DIFF
--- a/core/src/main/java/io/apigee/trireme/core/modules/ProcessWrap.java
+++ b/core/src/main/java/io/apigee/trireme/core/modules/ProcessWrap.java
@@ -839,7 +839,7 @@ public class ProcessWrap
 
             try {
                 script =
-                    parent.runner.getEnvironment().createScript(scriptPath, new File(scriptPath),
+                    parent.runner.getEnvironment().createScript(scriptPath, parent.runner.translatePath(scriptPath),
                                                                 args.toArray(new String[args.size()]));
                 script.setSandbox(scriptSandbox);
                 script.setWorkingDirectory(cwd);


### PR DESCRIPTION
When spawning child scripts, the path to the script file originates from JavaScript. As a consequence it must be translated from the sandbox to the Java machine.
