### PR TITLE
Trireme + Vert.X integration

### DIFF
--- a/core/src/main/java/io/apigee/trireme/core/ScriptFuture.java
+++ b/core/src/main/java/io/apigee/trireme/core/ScriptFuture.java
@@ -176,9 +176,21 @@ public class ScriptFuture
         notifyAll();
     }
 
+    public void setScriptStatus(ScriptStatus scriptStatus)
+    {
+    	set(scriptStatus);
+    }
+
     @Override
     public void run()
     {
+		synchronized(runner.getScriptObject()) {
+			// the synchronized block allows halting execution until wakeup is assigned
+			if (runner.wakeup != null) {
+				assert runner.getParentProcess() == null : "script is master and pumped externally";
+				return;
+			}
+		}
         try {
             ScriptStatus status = runner.call();
             set(status);


### PR DESCRIPTION
This pull request is NOT meant to be merged into trunk! I just offer these changes to demostrate the concept...

My team currently works on using Trireme as part of an application server. In our environment we run loads of scripts at the same time. An issue to us is that Trireme blocks a thread for each script executing. This is bad as most of the time the scripts have nothing to do.

On the other hand we have a Vert.X based infrastructure. Here, there is one event loop thread for each processor, say 4 thread for a quad core. For integration, the Trireme event loop needs to be splitt. We call:
- enterScript() just once to initialize the script,
- mainPump() is executed several times,
- leaveScript() finally cleans up the script when it is to be unloaded.

The trick is, mainPump() returns once the script becomes idle, control is passed to the outer client code running multiple script loops.

Even with loads of scripts, there are times when none has anything to do. In this case we want to block until some work is at hand. For this to work however, we need some notification to wake up the blocking event loop. This is implemented by using a wakeup Runnable that gets called whenever Trireme wants us to call the mainPump() for further processing. Finally, in ScriptFuture there is a tweak ensuring script execution waits until the wakeup object is installed.

All the code is pretty much hacked together. It works for me, but is not in a state I'd call production ready. Maybe this can be refactored to something offering the functionality required as public API. I also got code to hook in code preserving and restoring ThreadLocal states across asynchronous callback chains. Just like the thread-sharing feature, it is hacked together and I'm having a hard time getting this integrated. I suggest getting in touch to discuss if and how this can be integrated.

Best regards.
