### PR TITLE
Rhino context was not exited when fs.readdir(path) is called with a non-...

### DIFF
--- a/core/src/main/java/io/apigee/trireme/core/modules/AsyncFilesystem.java
+++ b/core/src/main/java/io/apigee/trireme/core/modules/AsyncFilesystem.java
@@ -919,10 +919,10 @@ public class AsyncFilesystem
             throws NodeOSException
         {
             Path sp = translatePath(dn);
-            Context cx = Context.enter();
             if (!Files.isDirectory(sp)) {
                 throw new NodeOSException(Constants.ENOTDIR, sp.toString());
             }
+            Context cx = Context.enter();
             try {
                 final ArrayList<String> paths = new ArrayList<String>();
                 Set<FileVisitOption> options = Collections.emptySet();


### PR DESCRIPTION
...existing path