### PR TITLE
allow setting a ClassLoader Supplier

### DIFF
--- a/core/src/main/java/io/apigee/trireme/core/modules/TriremeNativeSupport.java
+++ b/core/src/main/java/io/apigee/trireme/core/modules/TriremeNativeSupport.java
@@ -99,14 +99,18 @@ public class TriremeNativeSupport
                     throw Utils.makeError(cx, thisObj, "Cannot get URL for JAR file :" + e);
                 }
             }
+            URL[] urlArray = urls.toArray(new URL[urls.size()]);
 
             Sandbox sandbox = self.runtime.getSandbox();
             ClassLoader loader = null;
             if (sandbox != null) { // use custom class loader if specified
-                loader = sandbox.getClassLoader();
+                Sandbox.ClassLoaderSupplier supplier = sandbox.getClassLoaderSupplier();
+                if (supplier != null) {
+                    loader = supplier.getClassLoader(urlArray);
+                }
             }
             if (loader == null) { // fallback
-                loader = new URLClassLoader(urls.toArray(new URL[urls.size()]));
+                loader = new URLClassLoader(urlArray);
             }
 
             // Load the classes in to the module registry for this script only.

--- a/node10/node10src/src/test/java/io/apigee/trireme/node10/test/JarLoadingTest.java
+++ b/node10/node10src/src/test/java/io/apigee/trireme/node10/test/JarLoadingTest.java
@@ -106,7 +106,7 @@ public class JarLoadingTest
     public void testLoadingUsingCustomClassLoader()
             throws NodeException, InterruptedException, ExecutionException {
 
-        ArrayList<URL> urls = new ArrayList<URL>();
+        final ArrayList<URL> urls = new ArrayList<URL>();
         String[] jarNames = {"target/test-classes/testjar.jar", "target/test-classes/depjar.jar"};
         for (String jn : jarNames) {
             File jarFile = new File(jn);
@@ -121,9 +121,11 @@ public class JarLoadingTest
             }
         }
 
-        Sandbox sb = new Sandbox().setClassLoader(
-                new URLClassLoader(urls.toArray(new URL[urls.size()]))
-        );
+        Sandbox sb = new Sandbox().setClassLoaderSupplier(new Sandbox.ClassLoaderSupplier() {
+            public ClassLoader getClassLoader(URL[] urlArray) {
+                return new URLClassLoader(urls.toArray(new URL[urls.size()]));
+            }
+        });
         NodeScript script = env.createScript("jarload.js",
                 new File("target/test-classes/tests/jarload.js"),
                 new String[]{"Foo", "25"});
@@ -139,8 +141,12 @@ public class JarLoadingTest
     public void testLoadingFailsUsingInvalidCustomClassLoader()
             throws NodeException, InterruptedException, ExecutionException {
 
-        URL empty[] = new URL[0];
-        Sandbox sb = new Sandbox().setClassLoader(new URLClassLoader(empty));
+        final URL empty[] = new URL[0];
+        Sandbox sb = new Sandbox().setClassLoaderSupplier(new Sandbox.ClassLoaderSupplier() {
+            public ClassLoader getClassLoader(URL[] urlArray) {
+                return new URLClassLoader(empty);
+            }
+        });
         NodeScript script = env.createScript("jarload.js",
                 new File("target/test-classes/tests/jarload.js"),
                 new String[]{"Foo", "25"});


### PR DESCRIPTION
Specifying a ClassLoader Supplier instead of just a ClassLoader
instance gives more flexibility to the embedder by allowing the
embedder to choose if classes loaded by multiple innovations of
loadJars are isolated from each-other.