### PR TITLE
Make hash and signature algorithm mapping better.

### DIFF
--- a/core/src/main/java/io/apigee/trireme/core/modules/Crypto.java
+++ b/core/src/main/java/io/apigee/trireme/core/modules/Crypto.java
@@ -39,6 +39,7 @@ import io.apigee.trireme.core.modules.crypto.SecureContextImpl;
 import io.apigee.trireme.core.modules.crypto.SignImpl;
 import io.apigee.trireme.core.modules.crypto.VerifyImpl;
 import io.apigee.trireme.kernel.crypto.SSLCiphers;
+import io.apigee.trireme.kernel.crypto.SignatureAlgorithms;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.FunctionObject;
@@ -238,7 +239,7 @@ public class Crypto
         @SuppressWarnings("unused")
         public static Scriptable getHashes(Context cx, Scriptable thisObj, Object[] args, Function func)
         {
-            return cx.newArray(thisObj, HashImpl.SUPPORTED_ALGORITHMS.toArray());
+            return cx.newArray(thisObj, SignatureAlgorithms.get().getAlgorithms().toArray());
         }
 
         @JSFunction

--- a/core/src/main/java/io/apigee/trireme/core/modules/crypto/HashImpl.java
+++ b/core/src/main/java/io/apigee/trireme/core/modules/crypto/HashImpl.java
@@ -78,13 +78,14 @@ public class HashImpl
             alg = HashAlgorithms.get().getByJavaHashName(nodeAlgorithm);
         }
         if (alg == null) {
-            throw Utils.makeError(cx, ctorObj, "Digest method not supported");
+            throw Utils.makeError(cx, ctorObj, "Digest method not supported: " + nodeAlgorithm);
         }
 
         try {
             messageDigest = MessageDigest.getInstance(alg.getHashName());
         } catch (NoSuchAlgorithmException e) {
-            throw Utils.makeError(cx, ctorObj, "Digest method not supported: " + e);
+            throw Utils.makeError(cx, ctorObj,
+                "Digest method not supported: " + nodeAlgorithm + ": " + e);
         }
     }
 

--- a/core/src/main/java/io/apigee/trireme/core/modules/crypto/MacImpl.java
+++ b/core/src/main/java/io/apigee/trireme/core/modules/crypto/MacImpl.java
@@ -50,6 +50,7 @@ public class MacImpl
     static {
         MAC_ALGORITHMS.put("md5", "HmacMD5");
         MAC_ALGORITHMS.put("sha1", "HmacSHA1");
+        MAC_ALGORITHMS.put("sha224", "HmacSHA224");
         MAC_ALGORITHMS.put("sha256", "HmacSHA256");
         MAC_ALGORITHMS.put("sha384", "HmacSHA384");
         MAC_ALGORITHMS.put("sha512", "HmacSHA512");

--- a/core/src/main/java/io/apigee/trireme/core/modules/crypto/SignImpl.java
+++ b/core/src/main/java/io/apigee/trireme/core/modules/crypto/SignImpl.java
@@ -66,6 +66,9 @@ public class SignImpl
 
         self.algorithm = SignatureAlgorithms.get().get(algorithm);
         if (self.algorithm == null) {
+            self.algorithm = SignatureAlgorithms.get().getByJavaSigningName(algorithm);
+        }
+        if (self.algorithm == null) {
             throw Utils.makeError(cx, thisObj,
                                   "Invalid signature algorithm " + algorithm);
         }
@@ -111,7 +114,7 @@ public class SignImpl
 
         byte[] result;
         try {
-            Signature signer = Signature.getInstance(self.algorithm.getJavaName());
+            Signature signer = Signature.getInstance(self.algorithm.getSigningName());
             signer.initSign(pair.getPrivate());
 
             for (ByteBuffer bb : self.buffers) {

--- a/core/src/main/java/io/apigee/trireme/core/modules/crypto/VerifyImpl.java
+++ b/core/src/main/java/io/apigee/trireme/core/modules/crypto/VerifyImpl.java
@@ -70,6 +70,9 @@ public class VerifyImpl
 
         self.algorithm = SignatureAlgorithms.get().get(algorithm);
         if (self.algorithm == null) {
+            self.algorithm = SignatureAlgorithms.get().getByJavaSigningName(algorithm);
+        }
+        if (self.algorithm == null) {
             throw Utils.makeError(cx, thisObj,
                                   "Invalid verify algorithm " + algorithm);
         }
@@ -140,7 +143,7 @@ public class VerifyImpl
         }
 
         try {
-            Signature verifier = Signature.getInstance(self.algorithm.getJavaName());
+            Signature verifier = Signature.getInstance(self.algorithm.getSigningName());
             if (pubKey == null) {
                 verifier.initVerify(cert);
             } else {

--- a/kernel/src/main/java/io/apigee/trireme/kernel/crypto/HashAlgorithms.java
+++ b/kernel/src/main/java/io/apigee/trireme/kernel/crypto/HashAlgorithms.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Apigee Corporation.
+ * Copyright 2017 Apigee Corporation.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,14 +25,12 @@ import io.apigee.trireme.kernel.Charsets;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.security.Provider;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**

--- a/kernel/src/main/java/io/apigee/trireme/kernel/crypto/HashAlgorithms.java
+++ b/kernel/src/main/java/io/apigee/trireme/kernel/crypto/HashAlgorithms.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2013 Apigee Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.apigee.trireme.kernel.crypto;
+
+import io.apigee.trireme.kernel.Charsets;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.security.Provider;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class processes the installed security providers to identify those that support
+ * message digests. It maps "Openssl" style algorithm names to Java names.
+ */
+
+public class HashAlgorithms
+{
+  private static final HashAlgorithms myself = new HashAlgorithms();
+
+  private final HashMap<String, Algorithm> algs = new HashMap<String, Algorithm>();
+  private final HashMap<String, Algorithm> javaHashAlgs = new HashMap<String, Algorithm>();
+  private final ArrayList<String> algNames = new ArrayList<String>();
+
+  public static HashAlgorithms get() {
+    return myself;
+  }
+
+  private HashAlgorithms()
+  {
+    final Pattern WHITESPACE = Pattern.compile("[\\t ]+");
+    final Set<String> supportedAlgorithms = Security.getAlgorithms("MessageDigest");
+
+    // Read the file of the algorithms that we'd like to support
+    try {
+      BufferedReader rdr =
+          new BufferedReader(new InputStreamReader(SignatureAlgorithms.class.getResourceAsStream("/hashes.txt"),
+              Charsets.UTF8));
+      try {
+        String line;
+        do {
+          line = rdr.readLine();
+          if (line != null) {
+            if (line.startsWith("#")) {
+              continue;
+            }
+            String[] m = WHITESPACE.split(line);
+            if ((m.length == 2) && supportedAlgorithms.contains(m[1])) {
+              Algorithm alg = new Algorithm();
+              alg.setName(m[0].toUpperCase());
+              alg.setHashName(m[1]);
+              algNames.add(m[0]);
+              algs.put(m[0].toUpperCase(), alg);
+              javaHashAlgs.put(m[1], alg);
+            }
+          }
+        } while (line != null);
+
+      } finally {
+        rdr.close();
+      }
+
+    } catch (IOException ioe) {
+      throw new AssertionError("Can't read hashes file", ioe);
+    } catch (NumberFormatException nfe) {
+      throw new AssertionError("Invalid line in hashes file", nfe);
+    }
+
+    Collections.sort(algNames);
+  }
+
+  public Algorithm get(String name) {
+    return algs.get(name.toUpperCase());
+  }
+
+  public Algorithm getByJavaHashName(String name) {
+    return javaHashAlgs.get(name);
+  }
+
+  public List<String> getAlgorithms() {
+    return algNames;
+  }
+
+  public static class Algorithm
+  {
+    private String name;
+    private String hashName;
+
+    public String getName()
+    {
+      return name;
+    }
+
+    public void setName(String name)
+    {
+      this.name = name;
+    }
+
+    public String getHashName()
+    {
+      return hashName;
+    }
+
+    public void setHashName(String hashName)
+    {
+      this.hashName = hashName;
+    }
+  }
+}

--- a/kernel/src/main/resources/hashes.txt
+++ b/kernel/src/main/resources/hashes.txt
@@ -1,0 +1,60 @@
+# This file maps hashing algorithm names recognized by "crypto.createHash" in Node / OpenSSL
+# To "MessageDigest" algorithms in Java.
+# The mapping is confusing because OpenSSL maps names like "RSA-SHA256" to regular
+# digest algorithms like "sha256" even though "RSA-SHA256" is a signature algorithm
+# and not a message digest algorithm.
+# NOTE that the algorithm that OpenSSL calls "SHA-1" is what Java calls "SHA".
+# We verified this through testing.
+DSA                   DSA
+DSA-SHA               DSA
+DSA-SHA1              DSA
+DSA-SHA1-old          DSA
+DSS1                  DSA
+MD2                   MD2
+MD4                   MD4
+MD5                   MD5
+RIPEMD160             RIPEMD160
+RSA-MD4               MD4
+RSA-MD5               MD5
+RSA-RIPEMD160         RIPEMD160
+RSA-SHA               SHA-0
+RSA-SHA1              SHA
+RSA-SHA1-2            SHA
+RSA-SHA224            SHA-224
+RSA-SHA256            SHA-256
+RSA-SHA384            SHA-384
+RSA-SHA512            SHA-512
+SHA                   SHA-0
+SHA1                  SHA
+SHA224                SHA-224
+SHA256                SHA-256
+SHA384                SHA-384
+SHA512                SHA-512
+DSA                   DSA
+DSA-SHA               DSA
+dsaWithSHA1           DSA
+dss1                  DSA
+ecdsa-with-SHA1       ECDSA
+MD4                   MD4
+md4WithRSAEncryption  MD4
+MD5                   MD5
+md5WithRSAEncryption  MD5
+ripemd                RIPEMD160
+RIPEMD160             RIPEMD160
+ripemd160WithRSA      RIPEMD160
+rmd160                RIPEMD160
+SHA                   SHA-0
+SHA1                  SHA
+sha1WithRSAEncryption SHA
+SHA224                   SHA-224
+sha224WithRSAEncryption  SHA-224
+SHA256                   SHA-256
+sha256WithRSAEncryption  SHA-256
+SHA384                   SHA-384
+sha384WithRSAEncryption  SHA-384
+SHA512                   SHA-512
+sha512WithRSAEncryption  SHA-512
+shaWithRSAEncryption     SHA-0
+ssl2-md5                 MD5
+ssl3-md5                 MD5
+ssl3-sha1                SHA

--- a/kernel/src/main/resources/signatures.txt
+++ b/kernel/src/main/resources/signatures.txt
@@ -1,0 +1,42 @@
+# This file maps the algorithm names used by OpenSSL for signature algorithms
+# with those used by Java. The file has the following whitespace-separated format:
+# {OpenSSL Hash Name} {Java Signature algorithm name} {Key Format}
+# The result is somewhat confusing due to the strangeness of Node.js and OpenSSL.
+# For instance, the name "sha256" in Node.js and OpenSSL is an alias for "RSA-SHA256".
+DSA                  NONEWITHDSA         DSA
+DSA-SHA              SHA1WITHDSA         DSA
+DSA-SHA1             SHA1WITHDSA         DSA
+DSA-SHA1-OLD         SHA1WITHDSA         DSA
+DSS1                 SHA1WITHDSA         DSA
+DSA-SHA2224          SHA224WITHDSA       DSA
+DSA-SHA256           SHA256WITHDSA       DSA
+RSA-MD5              MD5WITHRSA          RSA
+RSA-MD5SHA1          MD5ANDSHA1WITHRSA   RSA
+RSA-MD2              MD2WITHRSA          RSA
+RSA-SHA              SHA1WITHRSA         NONE
+RSA-SHA1             SHA1WITHRSA         RSA
+RSA-SHA1-2           SHA1WITHRSA         RSA
+RSA-SHA224           SHA224WITHRSA       RSA
+RSA-SHA256           SHA256WITHRSA       RSA
+RSA-SHA384           SHA384WITHRSA       RSA
+RSA-SHA512           SHA512WITHRSA       RSA
+dsaWithSHA           SHA1WITHDSA         DSA
+dsaWithSHA1          SHA1WITHDSA         DSA
+ecdsa                NONEWITHECDSA       ECDSA
+ecdsa-with-SHA1      SHA1WITHECDSA       ECDSA
+ecdsa-with-SHA224    SHA224WITHECDSA     ECDSA
+ecdsa-with-SHA256    SHA256WITHECDSA     ECDSA
+ecdsa-with-SHA384    SHA384WITHECDSA     ECDSA
+ecdsa-with-SHA512    SHA512WITHECDSA     ECDSA
+md5                  MD5WITHRSA          RSA
+md5WithRSAEncryption MD5WITHRSA          RSA
+sha1                 SHA1WITHRSA         RSA
+sha1WithRSAEncryption SHA1WITHRSA        RSA
+sha224                SHA224WITHRSA      RSA
+sha224WithRSAEncryption  SHA224WITHRSA   RSA
+sha256                   SHA256WITHRSA   RSA
+sha256WithRSAEncryption  SHA256WITHRSA   RSA
+sha384                   SHA384WITHRSA   RSA
+sha384WithRSAEncryption  SHA384WITHRSA   RSA
+sha512                   SHA512WITHRSA   RSA
+sha512WithRSAEncryption  SHA512WITHRSA   RSA

--- a/kernel/src/test/java/io/apigee/trireme/kernel/test/CipherSuiteTest.java
+++ b/kernel/src/test/java/io/apigee/trireme/kernel/test/CipherSuiteTest.java
@@ -1,7 +1,11 @@
 package io.apigee.trireme.kernel.test;
 
 import io.apigee.trireme.kernel.crypto.CryptoAlgorithms;
+import io.apigee.trireme.kernel.crypto.HashAlgorithms;
 import io.apigee.trireme.kernel.crypto.SignatureAlgorithms;
+import java.security.Security;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -23,7 +27,7 @@ public class CipherSuiteTest
     }
 
     @Test
-    public void testNodeToJava()
+    public void testCipherNames()
     {
         // test the algorithms that the Java doc says will be available on all platforms
         ensureAlgorithm("aes-128-cbc", "AES/CBC/PKCS5Padding", 16, true);
@@ -54,9 +58,78 @@ public class CipherSuiteTest
     }
 
     @Test
-    public void dumpSignatureAlgorithms()
+    public void testSignatureNames()
     {
-        System.out.println(SignatureAlgorithms.get().getAlgorithms());
+        // Test common signature algorithms that we expect to see in the product
+        // and that we're pretty sure will be in every JVM
+        ensureSigner("RSA-SHA1", "SHA1WITHRSA", "RSA");
+        // Apparently some Node implementations support this as an alias for "RSA":
+        ensureSigner("sha256", "SHA256WITHRSA", "RSA");
+    }
+
+    private void ensureSigner(String name, String javaName, String keyFormat)
+    {
+        SignatureAlgorithms.Algorithm alg = SignatureAlgorithms.get().get(name);
+        assertNotNull(alg);
+        assertEquals(javaName, alg.getSigningName());
+        assertEquals(keyFormat, alg.getKeyFormat());
+    }
+
+    @Test
+    public void testHashNames()
+    {
+        ensureHash("sha256", "SHA-256");
+        ensureHash("rsa-sha256", "SHA-256");
+        ensureHash("sha224", "SHA-224");
+        ensureHash("sha1", "SHA");
+    }
+
+    private void ensureHash(String name, String javaName)
+    {
+        HashAlgorithms.Algorithm alg = HashAlgorithms.get().get(name);
+        assertNotNull(alg);
+        assertEquals(javaName, alg.getHashName());
+    }
+
+    /*
+     * This test will look at all the signature algorithms in the JVM and make sure that they have
+     * an entry in "hashes.txt." It is designed to fail when new algorithms are introduced
+     * to the JVM and we don't have mappings for them.
+     */
+    @Test
+    public void testMissingSignatureNames()
+    {
+        HashSet<String> missingAlgs = new HashSet<String>();
+        Set<String> allAlgs = Security.getAlgorithms("Signature");
+        missingAlgs.addAll(allAlgs);
+        for (String alg : allAlgs) {
+            if (SignatureAlgorithms.get().getByJavaSigningName(alg) != null) {
+                missingAlgs.remove(alg);
+            }
+        }
+        if (!missingAlgs.isEmpty()) {
+            System.out.println("Unsupported signature algorithms: " + missingAlgs);
+        }
+        assertTrue(missingAlgs.isEmpty());
+    }
+
+    @Test
+    public void testMissingHashNames()
+    {
+        System.out.println("MD ALGORITHMS: " + Security.getAlgorithms("MessageDigest"));
+        System.out.println("HASH ALGORITHMS: " + HashAlgorithms.get().getAlgorithms());
+        HashSet<String> missingAlgs = new HashSet<String>();
+        Set<String> allAlgs = Security.getAlgorithms("MessageDigest");
+        missingAlgs.addAll(allAlgs);
+        for (String alg : allAlgs) {
+            if (HashAlgorithms.get().getByJavaHashName(alg) != null) {
+                missingAlgs.remove(alg);
+            }
+        }
+        if (!missingAlgs.isEmpty()) {
+            System.out.println("Unsupported hash algorithms: " + missingAlgs);
+        }
+        assertTrue(missingAlgs.isEmpty());
     }
 
     /*

--- a/kernel/src/test/java/io/apigee/trireme/kernel/test/SSLCipherTest.java
+++ b/kernel/src/test/java/io/apigee/trireme/kernel/test/SSLCipherTest.java
@@ -32,6 +32,11 @@ public class SSLCipherTest
         assertEquals(128, c.getKeyLen());
     }
 
+    /*
+     * This test will look at all the ciphers in the JVM and make sure that they have
+     * an entry in "ciphers.txt." It is designed to fail when new algorithms are introduced
+     * to the JVM and we don't have mappings for them.
+     */
     @Test
     public void testAllCiphersSupported()
         throws GeneralSecurityException

--- a/node10/node10tests/noderunner/test-crypto-binary-default.js
+++ b/node10/node10tests/noderunner/test-crypto-binary-default.js
@@ -88,7 +88,7 @@ var rfc4231 = [
     key: new Buffer('0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b', 'hex'),
     data: new Buffer('4869205468657265', 'hex'), // 'Hi There'
     hmac: {
-      //sha224: '896fb1128abbdf196832107cd49df33f47b4b1169912ba4f53684b22',
+      sha224: '896fb1128abbdf196832107cd49df33f47b4b1169912ba4f53684b22',
       sha256:
           'b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c' +
           '2e32cff7',
@@ -106,7 +106,7 @@ var rfc4231 = [
     data: new Buffer('7768617420646f2079612077616e7420666f72206e6f74686' +
                      '96e673f', 'hex'), // 'what do ya want for nothing?'
     hmac: {
-      //sha224: 'a30e01098bc6dbbf45690f3a7e9e6d0f8bbea2a39e6148008fd05e44',
+      sha224: 'a30e01098bc6dbbf45690f3a7e9e6d0f8bbea2a39e6148008fd05e44',
       sha256:
           '5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b9' +
           '64ec3843',
@@ -125,7 +125,7 @@ var rfc4231 = [
                      'ddddddddddddddddddddddddddddddddddddddddddddddddddd',
                      'hex'),
     hmac: {
-      //sha224: '7fb3cb3588c6c1f6ffa9694d7d6ad2649365b0c1f65d69d1ec8333ea',
+      sha224: '7fb3cb3588c6c1f6ffa9694d7d6ad2649365b0c1f65d69d1ec8333ea',
       sha256:
           '773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514' +
           'ced565fe',
@@ -145,7 +145,7 @@ var rfc4231 = [
                      'dcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd',
                      'hex'),
     hmac: {
-      //sha224: '6c11506874013cac6a2abc1bb382627cec6a90d86efc012de7afec5a',
+      sha224: '6c11506874013cac6a2abc1bb382627cec6a90d86efc012de7afec5a',
       sha256:
           '82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff4' +
           '6729665b',
@@ -164,7 +164,7 @@ var rfc4231 = [
     // 'Test With Truncation'
     data: new Buffer('546573742057697468205472756e636174696f6e', 'hex'),
     hmac: {
-      //sha224: '0e2aea68a90c8d37c988bcdb9fca6fa8',
+      sha224: '0e2aea68a90c8d37c988bcdb9fca6fa8',
       sha256: 'a3b6167473100ee06e0c796c2955552b',
       sha384: '3abf34c3503b2a23a46efc619baef897',
       sha512: '415fad6271580a531d4179bc891d87a6'
@@ -183,7 +183,7 @@ var rfc4231 = [
                      'c6f636b2d53697a65204b6579202d2048617368204b657920' +
                      '4669727374', 'hex'),
     hmac: {
-      //sha224: '95e9a0db962095adaebe9b2d6f0dbce2d499f112f2d2b7273fa6870e',
+      sha224: '95e9a0db962095adaebe9b2d6f0dbce2d499f112f2d2b7273fa6870e',
       sha256:
           '60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f' +
           '0ee37f54',
@@ -214,7 +214,7 @@ var rfc4231 = [
                      'e6720757365642062792074686520484d414320616c676f72' +
                      '6974686d2e', 'hex'),
     hmac: {
-      //sha224: '3a854166ac5d9f023f54d517d0b39dbd946770db9c2b95c9f6f565d1',
+      sha224: '3a854166ac5d9f023f54d517d0b39dbd946770db9c2b95c9f6f565d1',
       sha256:
           '9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f5153' +
           '5c3a35e2',
@@ -646,11 +646,11 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 
   // DSA signatures vary across runs so there is no static string to verify
   // against
-  var sign = crypto.createSign('DSA-SHA1');
+  var sign = crypto.createSign('DSS1');
   sign.update(input);
   var signature = sign.sign(privateKey, 'hex');
 
-  var verify = crypto.createVerify('DSA-SHA1');
+  var verify = crypto.createVerify('DSS1');
   verify.update(input);
 
   assert.strictEqual(verify.verify(publicKey, signature, 'hex'), true);

--- a/node10/node10tests/noderunner/test-crypto.js
+++ b/node10/node10tests/noderunner/test-crypto.js
@@ -545,6 +545,15 @@ verStream.end('3');
 verified = verStream.verify(certPem, s3);
 assert.strictEqual(verified, true, 'sign and verify (stream)');
 
+var s4 = crypto.createSign('sha256')
+               .update('Test123')
+               .sign(keyPem, 'buffer');
+var verified = crypto.createVerify('sha256')
+                     .update('Test')
+                     .update('123')
+                     .verify(certPem, s4);
+assert.strictEqual(verified, true, 'sign and verify (buffer)');
+
 function testCipher1(key) {
   // Test encryption and decryption
   var plaintext = 'Keep this a secret? No! Tell everyone about node.js!';

--- a/node10/node10tests/noderunner/test-crypto.js
+++ b/node10/node10tests/noderunner/test-crypto.js
@@ -545,6 +545,9 @@ verStream.end('3');
 verified = verStream.verify(certPem, s3);
 assert.strictEqual(verified, true, 'sign and verify (stream)');
 
+// Verify that "sha256" is a valid alias for "RSA-SHA256"
+// the way that Node.js does it.
+// This is undocumented but real users depend on it.
 var s4 = crypto.createSign('sha256')
                .update('Test123')
                .sign(keyPem, 'buffer');

--- a/node10/node10tests/noderunner/test-crypto.js
+++ b/node10/node10tests/noderunner/test-crypto.js
@@ -141,7 +141,7 @@ var rfc4231 = [
     data: new Buffer('4869205468657265', 'hex'), // 'Hi There'
     hmac: {
       // No SHA224 in Java 6
-      //sha224: '896fb1128abbdf196832107cd49df33f47b4b1169912ba4f53684b22',
+      sha224: '896fb1128abbdf196832107cd49df33f47b4b1169912ba4f53684b22',
       sha256:
           'b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c' +
           '2e32cff7',
@@ -160,7 +160,7 @@ var rfc4231 = [
                      '96e673f', 'hex'), // 'what do ya want for nothing?'
     hmac: {
       // No SHA224 in Java 6
-      //sha224: 'a30e01098bc6dbbf45690f3a7e9e6d0f8bbea2a39e6148008fd05e44',
+      sha224: 'a30e01098bc6dbbf45690f3a7e9e6d0f8bbea2a39e6148008fd05e44',
       sha256:
           '5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b9' +
           '64ec3843',
@@ -179,7 +179,7 @@ var rfc4231 = [
                      'ddddddddddddddddddddddddddddddddddddddddddddddddddd',
                      'hex'),
     hmac: {
-      //sha224: '7fb3cb3588c6c1f6ffa9694d7d6ad2649365b0c1f65d69d1ec8333ea',
+      sha224: '7fb3cb3588c6c1f6ffa9694d7d6ad2649365b0c1f65d69d1ec8333ea',
       sha256:
           '773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514' +
           'ced565fe',
@@ -199,7 +199,7 @@ var rfc4231 = [
                      'dcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd',
                      'hex'),
     hmac: {
-      //sha224: '6c11506874013cac6a2abc1bb382627cec6a90d86efc012de7afec5a',
+      sha224: '6c11506874013cac6a2abc1bb382627cec6a90d86efc012de7afec5a',
       sha256:
           '82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff4' +
           '6729665b',
@@ -218,7 +218,7 @@ var rfc4231 = [
     // 'Test With Truncation'
     data: new Buffer('546573742057697468205472756e636174696f6e', 'hex'),
     hmac: {
-      //sha224: '0e2aea68a90c8d37c988bcdb9fca6fa8',
+      sha224: '0e2aea68a90c8d37c988bcdb9fca6fa8',
       sha256: 'a3b6167473100ee06e0c796c2955552b',
       sha384: '3abf34c3503b2a23a46efc619baef897',
       sha512: '415fad6271580a531d4179bc891d87a6'
@@ -237,7 +237,7 @@ var rfc4231 = [
                      'c6f636b2d53697a65204b6579202d2048617368204b657920' +
                      '4669727374', 'hex'),
     hmac: {
-      //sha224: '95e9a0db962095adaebe9b2d6f0dbce2d499f112f2d2b7273fa6870e',
+      sha224: '95e9a0db962095adaebe9b2d6f0dbce2d499f112f2d2b7273fa6870e',
       sha256:
           '60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f' +
           '0ee37f54',
@@ -268,7 +268,7 @@ var rfc4231 = [
                      'e6720757365642062792074686520484d414320616c676f72' +
                      '6974686d2e', 'hex'),
     hmac: {
-      //sha224: '3a854166ac5d9f023f54d517d0b39dbd946770db9c2b95c9f6f565d1',
+      sha224: '3a854166ac5d9f023f54d517d0b39dbd946770db9c2b95c9f6f565d1',
       sha256:
           '9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f5153' +
           '5c3a35e2',
@@ -794,11 +794,11 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 
   // DSA signatures vary across runs so there is no static string to verify
   // against
-  var sign = crypto.createSign('DSA-SHA1');
+  var sign = crypto.createSign('DSS1');
   sign.update(input);
   var signature = sign.sign(privateKey, 'hex');
 
-  var verify = crypto.createVerify('DSA-SHA1');
+  var verify = crypto.createVerify('DSS1');
   verify.update(input);
 
   assert.strictEqual(verify.verify(publicKey, signature, 'hex'), true);
@@ -900,3 +900,63 @@ assert.throws(function() {
   try { d.final('xxx') } catch (e) {  }
   try { d.final('xxx') } catch (e) {  }
 })();
+
+// Regression test for #5482: string to Cipher#update() should not assert.
+(function() {
+  var c = crypto.createCipher('aes192', '0123456789abcdef');
+  c.update('update');
+  c.final();
+})();
+
+// #5655 regression tests, 'utf-8' and 'utf8' are identical.
+(function() {
+  var c = crypto.createCipher('aes192', '0123456789abcdef');
+  c.update('update', '');  // Defaults to "utf8".
+  c.final('utf-8');  // Should not throw.
+
+  c = crypto.createCipher('aes192', '0123456789abcdef');
+  c.update('update', 'utf8');
+  c.final('utf-8');  // Should not throw.
+
+  c = crypto.createCipher('aes192', '0123456789abcdef');
+  c.update('update', 'utf-8');
+  c.final('utf8');  // Should not throw.
+})();
+
+// Regression tests for #5725: hex input that's not a power of two should
+// throw, not assert in C++ land.
+// TRIREME doesnot seem to throw here either
+/*
+assert.throws(function() {
+  crypto.createCipher('aes192', 'test').update('0', 'hex');
+}, /Bad input string/);
+
+assert.throws(function() {
+  crypto.createDecipher('aes192', 'test').update('0', 'hex');
+}, /Bad input string/);
+
+assert.throws(function() {
+  crypto.createHash('sha1').update('0', 'hex');
+}, /Bad input string/);
+
+assert.throws(function() {
+  crypto.createSign('RSA-SHA1').update('0', 'hex');
+}, /Bad input string/);
+
+assert.throws(function() {
+  crypto.createVerify('RSA-SHA1').update('0', 'hex');
+}, /Bad input string/);
+*/
+
+assert.throws(function() {
+  var private = [
+    '-----BEGIN RSA PRIVATE KEY-----',
+    'MIGrAgEAAiEA+3z+1QNF2/unumadiwEr+C5vfhezsb3hp4jAnCNRpPcCAwEAAQIgQNriSQK4',
+    'EFwczDhMZp2dvbcz7OUUyt36z3S4usFPHSECEQD/41K7SujrstBfoCPzwC1xAhEA+5kt4BJy',
+    'eKN7LggbF3Dk5wIQN6SL+fQ5H/+7NgARsVBp0QIRANxYRukavs4QvuyNhMx+vrkCEQCbf6j/',
+    'Ig6/HueCK/0Jkmp+',
+    '-----END RSA PRIVATE KEY-----',
+    ''
+  ].join('\n');
+  crypto.createSign('RSA-SHA256').update('test').sign(private);
+});


### PR DESCRIPTION
Use a mapping table like the ones that we use for ciphers already
to map "OpenSSL" names to "Java" names. This will make
crypto.createHash and crypto.createSign work more like the way
that Node.js works.