### PR TITLE
fix build of samples/apigee-edge-like-runner

### DIFF
--- a/samples/apigee-edge-like-runner/pom.xml
+++ b/samples/apigee-edge-like-runner/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <trireme.version>0.8.9</trireme.version>
+    <trireme.version>0.9.0-SNAPSHOT</trireme.version>
   </properties>
 
   <build>
@@ -66,6 +66,19 @@
       <groupId>io.apigee.trireme</groupId>
       <artifactId>trireme-net</artifactId>
       <version>${trireme.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.apigee.trireme</groupId>
+      <artifactId>trireme-shell</artifactId>
+      <version>${trireme.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/samples/apigee-edge-like-runner/src/test/java/io/apigee/trireme/apigee/edge/ApigeeEdgeLikeRunnerTest.java
+++ b/samples/apigee-edge-like-runner/src/test/java/io/apigee/trireme/apigee/edge/ApigeeEdgeLikeRunnerTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 Apigee Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.apigee.trireme.apigee.edge;
+
+import io.apigee.trireme.shell.test.ShellLauncher;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ApigeeEdgeLikeRunnerTest {
+    private static ShellLauncher launcher;
+
+    @BeforeClass
+    public static void init() {
+        launcher = new ShellLauncher();
+    }
+
+    /**
+     * This test just ensures the launcher runs.
+     *
+     * @throws IOException if there is an I/O error while running the launcher
+     * @throws InterruptedException if the running of the launcher is interrupted
+     */
+    @Test
+    public void testLauncherRuns() throws IOException, InterruptedException {
+        String out = launcher.execute(new String[] {
+                "-e",
+                "console.log('Hello, World');"
+        });
+        assertFalse(out.isEmpty());
+        assertEquals("Hello, World\n", out);
+    }
+}

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -11,6 +11,23 @@
   <artifactId>trireme-shell</artifactId>
   <version>0.9.0-SNAPSHOT</version>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>io.apigee.trireme</groupId>


### PR DESCRIPTION
Before this change, the launcher was built against differing versions of
Trireme and resulted in a runtime error when using it.  This commit
contains a test to ensure that running the launcher works.