### PR TITLE
conditionally run aes192 tests

### DIFF
--- a/node10/node10tests/noderunner/test-crypto.js
+++ b/node10/node10tests/noderunner/test-crypto.js
@@ -915,22 +915,22 @@ assert.throws(function() {
 
 // Regression test for #5482: string to Cipher#update() should not assert.
 (function() {
-  var c = crypto.createCipher('aes192', '0123456789abcdef');
+  var c = crypto.createCipher('aes128', '0123456789abcdef');
   c.update('update');
   c.final();
 })();
 
 // #5655 regression tests, 'utf-8' and 'utf8' are identical.
 (function() {
-  var c = crypto.createCipher('aes192', '0123456789abcdef');
+  var c = crypto.createCipher('aes128', '0123456789abcdef');
   c.update('update', '');  // Defaults to "utf8".
   c.final('utf-8');  // Should not throw.
 
-  c = crypto.createCipher('aes192', '0123456789abcdef');
+  c = crypto.createCipher('aes128', '0123456789abcdef');
   c.update('update', 'utf8');
   c.final('utf-8');  // Should not throw.
 
-  c = crypto.createCipher('aes192', '0123456789abcdef');
+  c = crypto.createCipher('aes128', '0123456789abcdef');
   c.update('update', 'utf-8');
   c.final('utf8');  // Should not throw.
 })();
@@ -940,11 +940,11 @@ assert.throws(function() {
 // TRIREME doesnot seem to throw here either
 /*
 assert.throws(function() {
-  crypto.createCipher('aes192', 'test').update('0', 'hex');
+  crypto.createCipher('aes128', 'test').update('0', 'hex');
 }, /Bad input string/);
 
 assert.throws(function() {
-  crypto.createDecipher('aes192', 'test').update('0', 'hex');
+  crypto.createDecipher('aes128', 'test').update('0', 'hex');
 }, /Bad input string/);
 
 assert.throws(function() {


### PR DESCRIPTION
Some JVMs do not export the AES-192 cipher and this commit makes the
aes192 tests run conditionally based on the availability of the cipher.