### PR TITLE
Fix crypto.pbkdf2* to work like node.js

### DIFF
--- a/core/src/main/java/io/apigee/trireme/core/ArgUtils.java
+++ b/core/src/main/java/io/apigee/trireme/core/ArgUtils.java
@@ -21,6 +21,7 @@
  */
 package io.apigee.trireme.core;
 
+import io.apigee.trireme.core.modules.Buffer;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.Function;
@@ -455,5 +456,20 @@ public class ArgUtils
             return null;
         }
         return (Scriptable)obj;
+    }
+
+    /**
+     * Return the argument at "pos" as a {@link Buffer.BufferImpl}, or throw an exception if the argument list is not
+     * long enough or if the argument at "pos" is not a {@link Buffer.BufferImpl}.
+     */
+    public static Buffer.BufferImpl bufferArg(Object[] args, int pos)
+    {
+        ensureArg(args, pos);
+
+        if (args[pos] instanceof Buffer.BufferImpl) {
+            return (Buffer.BufferImpl)args[pos];
+        } else {
+            throw new EvaluatorException("Not a Buffer");
+        }
     }
 }

--- a/kernel/src/main/java/io/apigee/trireme/kernel/util/StringUtils.java
+++ b/kernel/src/main/java/io/apigee/trireme/kernel/util/StringUtils.java
@@ -30,6 +30,7 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -144,7 +145,10 @@ public class StringUtils
             } while (result.isOverflow());
 
             writeBuf.flip();
-            return writeBuf;
+
+            // When supporting Base64, the created buffer can be larger than necessary.  This results in unnecessary and
+            // problematic empty bytes at the end of the byte array.  The approach below takes care of this.
+            return ByteBuffer.wrap(Arrays.copyOf(writeBuf.array(), writeBuf.limit()));
         }
 
         // Use default decoding options, and this is optimized for common charsets as well


### PR DESCRIPTION
Whenever attempting to use `crypto.pbkdf2*` APIs, any time a `Buffer`
was used as an input the results from Trireme would differ from node.js
and the result is that the verification would fail.  This commit fixes
that by making the following changes:

1. io.apigee.trireme.core.modules.Crypto$PBKDF2 now treats its input
   arguments as `Buffer` objects.
2. io.apigee.trireme.kernel.util.StringUtils#stringToBuffer now properly
   handles base64 encoded strings such that the returned `ByteBuffer`
   only includes populated bytes.  Before this change, if the actual
   bytes in the Node.js `Buffer` were less than the `ByteBuffer`
   allocated, the returned `byte[]` would have extra bytes on the end
   and this broke `crypto.pbkdf2*`.
3. Tests were added to prove `crypto.pbkdf2*` works identically to
   node.js and the previously commented out PBKDF2 tests were
   uncommented.