### PR TITLE
buffer: return undefined when accessing negative Buffer index

### DIFF
--- a/core/src/main/java/io/apigee/trireme/core/modules/Buffer.java
+++ b/core/src/main/java/io/apigee/trireme/core/modules/Buffer.java
@@ -771,7 +771,7 @@ public class Buffer
         @Override
         public Object get(int index, Scriptable start)
         {
-            if (index < bufLength) {
+            if (index > -1 && index < bufLength) {
                 return get(index);
             }
             return Undefined.instance;

--- a/node10/node10tests/noderunner/test-buffer-noderunner.js
+++ b/node10/node10tests/noderunner/test-buffer-noderunner.js
@@ -1054,3 +1054,20 @@ assert.doesNotThrow(function () {
   var fast = new Buffer(1);
   assert(fast.write('', Buffer.poolSize * 10) === 0);
 });
+
+// Issue 143: Make sure accessing a Buffer with a negative index returns undefined
+(function() {
+  var buf1 = new Buffer("1111", "hex");
+  var buf2 = buf1.slice(1);
+
+  assert.strictEqual(buf1[-1], undefined);
+  assert.strictEqual(buf2[-1], undefined);
+
+  // Just making sure we didn't mess up the get by offset
+  assert.throws(function() {
+    buf1.get(-1)
+  }, RangeError);
+  assert.throws(function() {
+    buf2.get(-1)
+  }, RangeError);
+})();


### PR DESCRIPTION
Prior to this change, when accessing a Buffer with a negative index, a
Java error (java.lang.ArrayIndexOutOfBoundsException) was thrown instead
of returning `undefined` per standard node.js functionality.

Fixes #143