### PR TITLE
http: Allow embedding tools to configure http.globalAgent.maxSockets

### DIFF
--- a/node10/node10src/src/main/javascript/io/apigee/trireme/node10/trireme/adaptorhttp.js
+++ b/node10/node10src/src/main/javascript/io/apigee/trireme/node10/trireme/adaptorhttp.js
@@ -58,6 +58,16 @@ exports.get = NodeHttp.get;
 exports.Client = NodeHttp.Client;
 exports.createClient = NodeHttp.createClient;
 
+/*
+ * Allow the tool embedding Trireme to configure the default
+ * http.globalAgent.maxSockets.
+ */
+var customMaxSockets = toNumber(process.env.NODE_HTTP_MAX_SOCKETS);
+
+if (customMaxSockets) {
+  exports.globalAgent.maxSockets = customMaxSockets;
+}
+
 if (HttpWrap.hasServerAdapter()) {
   var util = require('util');
   var net = require('net');

--- a/node10/node10src/src/test/java/io/apigee/trireme/node10/test/BasicTest.java
+++ b/node10/node10src/src/test/java/io/apigee/trireme/node10/test/BasicTest.java
@@ -334,6 +334,27 @@ public class BasicTest
     }
 
     @Test
+    public void testHttpCustomDefaultMaxSockets()
+            throws InterruptedException, ExecutionException, NodeException, IOException
+    {
+        runTest("httpcustomdefaultmaxsockets.js");
+    }
+
+    @Test
+    public void testHttpDefaultMaxSockets()
+            throws InterruptedException, ExecutionException, NodeException, IOException
+    {
+        runTest("httpdefaultmaxsockets.js");
+    }
+
+    @Test
+    public void testHttpInvalidCustomDefaultMaxSockets()
+            throws InterruptedException, ExecutionException, NodeException, IOException
+    {
+        runTest("httpinvalidcustomdefaultmaxsockets.js");
+    }
+
+    @Test
     public void testHttpPolicy()
         throws InterruptedException, ExecutionException, NodeException, IOException
     {

--- a/node10/node10src/src/test/resources/tests/httpcustomdefaultmaxsockets.js
+++ b/node10/node10src/src/test/resources/tests/httpcustomdefaultmaxsockets.js
@@ -1,0 +1,6 @@
+var customMaxSockets = process.env.NODE_HTTP_MAX_SOCKETS = 10;
+
+var http = require('http');
+var assert = require('assert');
+
+assert.equal(http.globalAgent.maxSockets, customMaxSockets);

--- a/node10/node10src/src/test/resources/tests/httpdefaultmaxsockets.js
+++ b/node10/node10src/src/test/resources/tests/httpdefaultmaxsockets.js
@@ -1,0 +1,4 @@
+var http = require('http');
+var assert = require('assert');
+
+assert.equal(http.globalAgent.maxSockets, 5);

--- a/node10/node10src/src/test/resources/tests/httpinvalidcustomdefaultmaxsockets.js
+++ b/node10/node10src/src/test/resources/tests/httpinvalidcustomdefaultmaxsockets.js
@@ -1,0 +1,6 @@
+var customMaxSockets = process.env.NODE_HTTP_MAX_SOCKETS = "invalid";
+
+var http = require('http');
+var assert = require('assert');
+
+assert.equal(http.globalAgent.maxSockets, 5);


### PR DESCRIPTION
This commit adds support such that setting the `NODE_HTTP_MAX_SOCKETS`
environment variable will allow Trireme to override the default
`http.globalAgent.maxSockets` value of `5` with whatever value is in
the aforementioned environment variable.