### PR TITLE
make HTTP adaptor handling exit/uncaught exceptions configurable

### DIFF
--- a/net/src/test/java/io/apigee/trireme/netty/test/BasicHttpNettyTest.java
+++ b/net/src/test/java/io/apigee/trireme/netty/test/BasicHttpNettyTest.java
@@ -192,6 +192,18 @@ public class BasicHttpNettyTest
         }
     }
 
+    @Test(expected = TimeoutException.class)
+    public void testHTTPAdaptorHandlesUncaughtExceptions()
+            throws ExecutionException, InterruptedException, NodeException, TimeoutException
+    {
+        NodeScript script = createTestScript("httpadaptorhandlesuncaughtexceptions.js");
+
+        script.addEnvironment("HTTP_ADAPTOR_HANDLES_UNCAUGHT_EXCEPTIONS", "true");
+
+        // Enabling this feature should throw a TimeoutException
+        script.execute().get(2, TimeUnit.SECONDS);
+    }
+
     private NodeScript createTestScript(String name)
             throws NodeException
     {

--- a/net/src/test/resources/tests/httpadaptorhandlesuncaughtexceptions.js
+++ b/net/src/test/resources/tests/httpadaptorhandlesuncaughtexceptions.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * Prior to 0.9.0, uncaught exceptions thrown outside of a domain-wrapped request handler were handled by the HTTP
+ * adaptor.  This was not ideal but for some consumers, altering this functionality resulted in breaking backward
+ * compatibility because unmodified code was all the sudden exiting.  While this bug deserves to be fixed, and is by
+ * default, consumers can tell Trireme that its HTTP adaptor will handle uncaught exceptions to provide backward
+ * compatibility.
+ */
+
+var assert = require('assert');
+var http = require('http');
+
+var server = http.createServer(function(req, resp) {});
+
+setTimeout(function() {
+  throw new Error('Uncaught Error');
+}, 500);
+
+server.listen(1235);

--- a/node10/node10src/src/main/javascript/io/apigee/trireme/node10/trireme/adaptorhttp.js
+++ b/node10/node10src/src/main/javascript/io/apigee/trireme/node10/trireme/adaptorhttp.js
@@ -659,6 +659,31 @@ if (HttpWrap.hasServerAdapter()) {
     };
     self._adapter.onclose = onClose;
 
+    // Prior to 0.9.0, uncaught exceptions thrown outside of a domain-wrapped request handler were handled by the HTTP
+    // adaptor.  This was not ideal but for some consumers, altering this functionality resulted in breaking backward
+    // compatibility because unmodified code was all the sudden exiting.  While this bug deserves to be fixed, and is by
+    // default, consumers can tell Trireme that its HTTP adaptor will handle uncaught exceptions to provide backward
+    // compatibility.
+    if ((process.env.HTTP_ADAPTOR_HANDLES_UNCAUGHT_EXCEPTIONS || 'false').toLowerCase() === 'true') {
+      process.on('uncaughtException', function(err) {
+        if ((self._adapter !== null) && !self.exiting) {
+          self.exiting = true;
+          var msg = getErrorMessage(err);
+          var stack = err.stack ? err.stack : undefined;
+          self._adapter.fatalError(msg, stack);
+        }
+      });
+    }
+    // Same as above.
+    if ((process.env.HTTP_ADAPTOR_HANDLES_EXIT || 'false').toLowerCase() === 'true') {
+      process.on('exit', function() {
+        if ((self._adapter !== null) && !self.exiting) {
+          self.exiting = true;
+          self._adapter.fatalError('Premature script exit');
+        }
+      });
+    }
+
     process.nextTick(function() {
       self.emit('listening');
     });


### PR DESCRIPTION
This commit uses two environment variables to make it where the HTTP
adaptor can handle `exit` and `uncaughtException` events like it did
prior to `0.9.0`.  Since `0.9.0` fixed a bug, this default behavior
of Trireme stays the same but this new feature does allow embedders
the ability to have backward compatibility prior to `0.9.0` when it
comes to this.

Fixes #78