### PR TITLE
Fix Buffer.getBuffer() when Buffer has an offset set for its underlying array

### DIFF
--- a/core/src/main/java/io/apigee/trireme/core/modules/Buffer.java
+++ b/core/src/main/java/io/apigee/trireme/core/modules/Buffer.java
@@ -731,7 +731,20 @@ public class Buffer
 
         public ByteBuffer getBuffer()
         {
-            return ByteBuffer.wrap(buf, bufOffset, bufLength);
+
+            // https://github.com/apigee/trireme/issues/181
+            // For cases where Trireme's Buffer is using a byte buffer with an offset we must copy the in-use portion of
+            // the byte[] to a new byte array and pass that to ByteBuffer.wrap(). ByteBuffer.wrap does not support
+            // setting an offset the offset used below sets the current position not the underlying offset.
+            //
+            // From https://docs.oracle.com/javase/7/docs/api/java/nio/ByteBuffer.html#wrap(byte%5B%5D,%20int,%20int)
+            // "Its backing array will be the given array, and its array offset will be zero."
+            if (bufOffset != 0) {
+                ByteBuffer newBuf = ByteBuffer.wrap(buf, bufOffset, bufLength);
+                return newBuf.slice();
+            } else {
+                return ByteBuffer.wrap(buf, bufOffset, bufLength);
+            }
         }
 
         public String getString(String encoding)

--- a/node10/node10tests/internet/test-dns.js
+++ b/node10/node10tests/internet/test-dns.js
@@ -266,9 +266,12 @@ TEST(function test_resolveCname(done) {
 TEST(function test_resolveTxt(done) {
   var req = dns.resolveTxt('google.com', function(err, records) {
     if (err) throw err;
-    assert.equal(records.length, 1);
-    assert.equal(records[0].indexOf('v=spf1'), 0);
-    done();
+    assert(records.length > 1);
+    records.forEach(function(record) {
+      if (record.indexOf('v=spf1') == 0) {
+        done();
+      }
+    })
   });
 
   checkWrap(req);

--- a/node10/node10tests/simple/zlib-fails-with-http.js
+++ b/node10/node10tests/simple/zlib-fails-with-http.js
@@ -1,0 +1,35 @@
+var assert = require('assert');
+var http = require('http');
+var zlib = require('zlib');
+var common = require('../common');
+
+http.createServer(function(req, res) {
+  res.setHeader('Content-Encoding', 'gzip');
+  // gzip of "abc\n"
+  var buf = new Buffer([0x1f, 0x8b, 0x08, 0x00, 0x9a, 0x2d, 0xb0, 0x5a, 0x00, 0x03, 0x4b, 0x4c, 0x4a, 0xe6, 0x02, 0x00, 0x4e, 0x81, 0x88, 0x47, 0x04, 0x00, 0x00, 0x00]);
+  res.end(buf);
+}).listen(common.PORT, function(err) {
+  if (err) {
+    throw err;
+  }
+
+  var opts = {
+    host: 'localhost',
+    port: common.PORT,
+    path: '/test',
+    headers: {
+      'Accept-Encoding': 'gzip'
+    }
+  };
+
+  var req = http.request(opts, function(res) {
+    var unzip = zlib.createUnzip();
+    unzip.on('data', function(data) {
+        assert.equal(data.toString(), "abc\n");
+    })
+    unzip.on('end', function() {
+        process.exit(0);
+    })
+    res.pipe(unzip);
+  }).end();
+});

--- a/node12/node12tests/simple/zlib-fails-with-http.js
+++ b/node12/node12tests/simple/zlib-fails-with-http.js
@@ -1,0 +1,35 @@
+var assert = require('assert');
+var http = require('http');
+var zlib = require('zlib');
+var common = require('../common');
+
+http.createServer(function(req, res) {
+  res.setHeader('Content-Encoding', 'gzip');
+  // gzip of "abc\n"
+  var buf = new Buffer([0x1f, 0x8b, 0x08, 0x00, 0x9a, 0x2d, 0xb0, 0x5a, 0x00, 0x03, 0x4b, 0x4c, 0x4a, 0xe6, 0x02, 0x00, 0x4e, 0x81, 0x88, 0x47, 0x04, 0x00, 0x00, 0x00]);
+  res.end(buf);
+}).listen(common.PORT, function(err) {
+  if (err) {
+    throw err;
+  }
+
+  var opts = {
+    host: 'localhost',
+    port: common.PORT,
+    path: '/test',
+    headers: {
+      'Accept-Encoding': 'gzip'
+    }
+  };
+
+  var req = http.request(opts, function(res) {
+    var unzip = zlib.createUnzip();
+    unzip.on('data', function(data) {
+        assert.equal(data.toString(), "abc\n");
+    })
+    unzip.on('end', function() {
+        process.exit(0);
+    })
+    res.pipe(unzip);
+  }).end();
+});


### PR DESCRIPTION
`ByteBuffer.wrap()` was not previously setting the offset correctly
`Buffer` was setting the position for the `ByteBuffer` assuming it
meant offset.

Because [ByteBuffer]( https://docs.oracle.com/javase/7/docs/api/java/nio/ByteBuffer.html#wrap(byte[],%20int,%20int))
does not support setting the offset _"Its backing array will be
the given array, and its array offset will be zero."_. Because of
this we create an array copy of the usable array in `Buffer` and pass
that to `ByteBuffer.wrap`. This only applies to caes where an offset
is set to avoid unnecessary copies of the array.

This causes an error #181 for zlib compression when the Buffer comes
from the HttpParser since the body is just an offset of the underlying
full http message returned.